### PR TITLE
Fixes Bug "invalid string value" for Apache 2.4.37

### DIFF
--- a/zbxApacheStatusCheck
+++ b/zbxApacheStatusCheck
@@ -12,7 +12,7 @@
 #
  
 name="zbxApacheStatusCheck"
-version="0.4"
+version="0.4.1"
 
 # Test  if  your  getopt(1)  is this enhanced version or an old version
 getopt --test > /dev/null
@@ -293,7 +293,7 @@ if [[ $RET_VAL = 0 ]]; then
 			echo -n "\"$ZABBIXSOURCE\" \"custom.apache[$STATNAME]\" " >> $SENDERFILE
 			LINE=`fgrep -w "$STATNAME:" $STATUSFILE`
 			if [[ $? = 0 ]]; then
-				echo $LINE | sed "s/$STATNAME: //" >> $SENDERFILE
+				echo "$LINE" | head -1 | sed "s/$STATNAME: //" >> $SENDERFILE
 			else
 				echo 0 >> $SENDERFILE;
 			fi


### PR DESCRIPTION
I ran over a bug showing "BusyWorkers" two times in the server-status output. So I just use the first one...